### PR TITLE
fix: Fix the nested fragment parent element reference

### DIFF
--- a/listings/ch04/listing_03.js
+++ b/listings/ch04/listing_03.js
@@ -4,6 +4,6 @@ function createFragmentNode(vdom, parentEl) {
   const fragment = document.createDocumentFragment() //--1--
   vdom.el = parentEl //--2--
 
-  children.forEach((child) => mountDOM(child, fragment)) //--3--
+  children.forEach((child) => mountDOM(child, parentEl)) //--3--
   parentEl.append(fragment) //--4--
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fe-fwk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A frontend framework to teach web developers how frontend frameworks work.",
   "keywords": [
     "frontend",

--- a/packages/runtime/src/__tests__/mount-dom.test.js
+++ b/packages/runtime/src/__tests__/mount-dom.test.js
@@ -72,7 +72,19 @@ test('mount a fragment inside a fragment inside a host element', () => {
   expect(document.body.innerHTML).toBe('<p>foo</p><p>bar</p><p>baz</p>')
 })
 
-test('mount fragment with children and attributes', () => {
+test('all nested fragments el references point to the parent element (where they are mounted)', () => {
+  const vdomOne = hFragment([hString('hello, '), hString('world')])
+  const vdomTwo = hFragment([vdomOne])
+  const vdomThree = hFragment([vdomTwo])
+
+  mountDOM(vdomThree, document.body)
+
+  expect(vdomThree.el).toBe(document.body)
+  expect(vdomTwo.el).toBe(document.body)
+  expect(vdomOne.el).toBe(document.body)
+})
+
+test('mount fragment with children that have attributes', () => {
   const vdom = hFragment([
     h('span', { id: 'foo' }, [hString('hello, ')]),
     h('span', { id: 'bar' }, [hString('world')]),

--- a/packages/runtime/src/mount-dom.js
+++ b/packages/runtime/src/mount-dom.js
@@ -117,7 +117,7 @@ function createFragmentNode(vdom, parentEl, index) {
   const fragment = document.createDocumentFragment()
   vdom.el = parentEl
 
-  children.forEach((child) => mountDOM(child, fragment))
+  children.forEach((child) => mountDOM(child, parentEl))
   insert(fragment, parentEl, index)
 }
 


### PR DESCRIPTION
Fixes #77 

The `createFragmentNode()` wasn't setting the correct parent element to nested fragments.