### PR TITLE
Fix: Stop using native fragments in favor of just appending the children

### DIFF
--- a/listings/ch04/listing_01.js
+++ b/listings/ch04/listing_01.js
@@ -13,7 +13,7 @@ export function mountDOM(vdom, parentEl) {
     }
 
     case DOM_TYPES.FRAGMENT: {
-      createFragmentNode(vdom, parentEl) // --3--
+      createFragmentNodes(vdom, parentEl) // --3--
       break
     }
 
@@ -27,4 +27,4 @@ export function mountDOM(vdom, parentEl) {
 
 // TODO: implement createElementNode()
 
-// TODO: implement createFragmentNode()
+// TODO: implement createFragmentNodes()

--- a/listings/ch04/listing_03.js
+++ b/listings/ch04/listing_03.js
@@ -2,5 +2,5 @@ function createFragmentNodes(vdom, parentEl) {
   const { children } = vdom
   vdom.el = parentEl //--1--
 
-  children.forEach((child) => mountDOM(child, parent)) //--2--
+  children.forEach((child) => mountDOM(child, parentEl)) //--2--
 }

--- a/listings/ch04/listing_03.js
+++ b/listings/ch04/listing_03.js
@@ -1,9 +1,6 @@
-function createFragmentNode(vdom, parentEl) {
+function createFragmentNodes(vdom, parentEl) {
   const { children } = vdom
+  vdom.el = parentEl //--1--
 
-  const fragment = document.createDocumentFragment() //--1--
-  vdom.el = parentEl //--2--
-
-  children.forEach((child) => mountDOM(child, parentEl)) //--3--
-  parentEl.append(fragment) //--4--
+  children.forEach((child) => mountDOM(child, parent)) //--2--
 }

--- a/listings/ch04/listing_11.js
+++ b/listings/ch04/listing_11.js
@@ -16,7 +16,7 @@ export function destroyDOM(vdom) {
     }
 
     case DOM_TYPES.FRAGMENT: {
-      removeFragmentNode(vdom)
+      removeFragmentNodes(vdom)
       break
     }
 
@@ -32,4 +32,4 @@ export function destroyDOM(vdom) {
 
 // TODO: implement removeElementNode()
 
-// TODO: implement removeFragmentNode()
+// TODO: implement removeFragmentNodes()

--- a/listings/ch04/listing_15.js
+++ b/listings/ch04/listing_15.js
@@ -1,4 +1,4 @@
-function removeFragmentNode(vdom) {
+function removeFragmentNodes(vdom) {
   const { children } = vdom
   children.forEach(destroyDOM)
 }

--- a/listings/ch06/listing_02.js
+++ b/listings/ch06/listing_02.js
@@ -1,8 +1,4 @@
-import {
-  createApp,
-  h,
-  hFragment,
-} from '../../packages/runtime/dist/_<fwk-name>_'
+import { createApp, h, hFragment } from 'https://unpkg.com/_<fwk-name>_@1'
 
 const state = {
   currentTodo: '',

--- a/listings/ch08/listing_02.js
+++ b/listings/ch08/listing_02.js
@@ -11,7 +11,7 @@ export function mountDOM(vdom, parentEl, /*--add--*/index/*--add--*/) {
     }
 
     case DOM_TYPES.FRAGMENT: {
-      createFragmentNode(vdom, parentEl, /*--add--*/index/*--add--*/)
+      createFragmentNodes(vdom, parentEl)
       break
     }
 

--- a/listings/ch08/listing_05.js
+++ b/listings/ch08/listing_05.js
@@ -1,14 +1,16 @@
-function createFragmentNode(vdom, parentEl, /*--add--*/index/*--add--*/) {
-  const { children } = vdom
+import { DOM_TYPES } from './h'
 
-  const fragment = document.createDocumentFragment()
-  vdom.el = parentEl
+export function areNodesEqual(nodeOne, nodeTwo) {
+  if (nodeOne.type !== nodeTwo.type) { // --1--
+    return false
+  }
 
-  children.forEach((child) => mountDOM(child, fragment))
-  // --remove--
-  parentEl.append(fragment)
-  // --remove--
-  // --add--
-  insert(fragment, parentEl, index)
-  // --add--
+  if (nodeOne.type === DOM_TYPES.ELEMENT) {
+    const { tag: tagOne } = nodeOne
+    const { tag: tagTwo } = nodeTwo
+
+    return tagOne === tagTwo // --2--
+  }
+
+  return true
 }

--- a/listings/ch08/listing_06.js
+++ b/listings/ch08/listing_06.js
@@ -1,16 +1,13 @@
-import { DOM_TYPES } from './h'
+import { destroyDOM } from './destroy-dom'
+import { mountDOM } from './mount-dom'
+import { areNodesEqual } from './nodes-equal'
 
-export function areNodesEqual(nodeOne, nodeTwo) {
-  if (nodeOne.type !== nodeTwo.type) { // --1--
-    return false
+export function patchDOM(oldVdom, newVdom, parentEl) {
+  if (!areNodesEqual(oldVdom, newVdom)) {
+    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el) // --1--
+    destroyDOM(oldVdom) // --2--
+    mountDOM(newVdom, parentEl, index) // --3--
+
+    return newVdom
   }
-
-  if (nodeOne.type === DOM_TYPES.ELEMENT) {
-    const { tag: tagOne } = nodeOne
-    const { tag: tagTwo } = nodeTwo
-
-    return tagOne === tagTwo // --2--
-  }
-
-  return true
 }

--- a/listings/ch08/listing_07.js
+++ b/listings/ch08/listing_07.js
@@ -1,13 +1,29 @@
 import { destroyDOM } from './destroy-dom'
+// --add--
+import { DOM_TYPES } from './h'
+// --add--
 import { mountDOM } from './mount-dom'
 import { areNodesEqual } from './nodes-equal'
 
 export function patchDOM(oldVdom, newVdom, parentEl) {
   if (!areNodesEqual(oldVdom, newVdom)) {
-    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el) // --1--
-    destroyDOM(oldVdom) // --2--
-    mountDOM(newVdom, parentEl, index) // --3--
+    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el)
+    destroyDOM(oldVdom)
+    mountDOM(newVdom, parentEl, index)
 
     return newVdom
   }
+
+  // --add--
+  newVdom.el = oldVdom.el // --1--
+
+  switch (newVdom.type) {
+    case DOM_TYPES.TEXT: {
+      patchText(oldVdom, newVdom) // --2--
+      return newVdom // --3--
+    }
+  }
+
+  return newVdom
+  // --add--
 }

--- a/listings/ch08/listing_08.js
+++ b/listings/ch08/listing_08.js
@@ -1,29 +1,9 @@
-import { destroyDOM } from './destroy-dom'
-// --add--
-import { DOM_TYPES } from './h'
-// --add--
-import { mountDOM } from './mount-dom'
-import { areNodesEqual } from './nodes-equal'
+function patchText(oldVdom, newVdom) {
+  const el = oldVdom.el
+  const { value: oldText } = oldVdom
+  const { value: newText } = newVdom
 
-export function patchDOM(oldVdom, newVdom, parentEl) {
-  if (!areNodesEqual(oldVdom, newVdom)) {
-    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el)
-    destroyDOM(oldVdom)
-    mountDOM(newVdom, parentEl, index)
-
-    return newVdom
+  if (oldText !== newText) {
+    el.nodeValue = newText
   }
-
-  // --add--
-  newVdom.el = oldVdom.el // --1--
-
-  switch (newVdom.type) {
-    case DOM_TYPES.TEXT: {
-      patchText(oldVdom, newVdom) // --2--
-      return newVdom // --3--
-    }
-  }
-
-  return newVdom
-  // --add--
 }

--- a/listings/ch08/listing_09.js
+++ b/listings/ch08/listing_09.js
@@ -1,9 +1,32 @@
-function patchText(oldVdom, newVdom) {
-  const el = oldVdom.el
-  const { value: oldText } = oldVdom
-  const { value: newText } = newVdom
+import { destroyDOM } from './destroy-dom'
+import { DOM_TYPES } from './h'
+import { mountDOM } from './mount-dom'
+import { areNodesEqual } from './nodes-equal'
 
-  if (oldText !== newText) {
-    el.nodeValue = newText
+export function patchDOM(oldVdom, newVdom, parentEl) {
+  if (!areNodesEqual(oldVdom, newVdom)) {
+    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el)
+    destroyDOM(oldVdom)
+    mountDOM(newVdom, parentEl, index)
+
+    return newVdom
   }
+
+  newVdom.el = oldVdom.el
+  
+  switch (newVdom.type) {
+    case DOM_TYPES.TEXT: {
+      patchText(oldVdom, newVdom)
+      return newVdom
+    }
+
+    // --add--
+    case DOM_TYPES.ELEMENT: {
+      patchElement(oldVdom, newVdom)
+      break
+    }
+    // --add--
+  }
+
+  return newVdom
 }

--- a/listings/ch08/listing_10.js
+++ b/listings/ch08/listing_10.js
@@ -1,32 +1,29 @@
-import { destroyDOM } from './destroy-dom'
-import { DOM_TYPES } from './h'
-import { mountDOM } from './mount-dom'
-import { areNodesEqual } from './nodes-equal'
+function patchElement(oldVdom, newVdom) {
+  const el = oldVdom.el
+  const {
+    class: oldClass,
+    style: oldStyle,
+    on: oldEvents,
+    ...oldAttrs
+  } = oldVdom.props
+  const {
+    class: newClass,
+    style: newStyle,
+    on: newEvents,
+    ...newAttrs
+  } = newVdom.props
+  const { listeners: oldListeners } = oldVdom
 
-export function patchDOM(oldVdom, newVdom, parentEl) {
-  if (!areNodesEqual(oldVdom, newVdom)) {
-    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el)
-    destroyDOM(oldVdom)
-    mountDOM(newVdom, parentEl, index)
-
-    return newVdom
-  }
-
-  newVdom.el = oldVdom.el
-  
-  switch (newVdom.type) {
-    case DOM_TYPES.TEXT: {
-      patchText(oldVdom, newVdom)
-      return newVdom
-    }
-
-    // --add--
-    case DOM_TYPES.ELEMENT: {
-      patchElement(oldVdom, newVdom)
-      break
-    }
-    // --add--
-  }
-
-  return newVdom
+  patchAttrs(el, oldAttrs, newAttrs)
+  patchClasses(el, oldClass, newClass)
+  patchStyles(el, oldStyle, newStyle)
+  newVdom.listeners = patchEvents(el, oldListeners, oldEvents, newEvents)
 }
+
+// TODO: implement patchAttrs()
+
+// TODO: implement patchClasses()
+
+// TODO: implement patchStyles()
+
+// TODO: implement patchEvents()

--- a/listings/ch08/listing_11.js
+++ b/listings/ch08/listing_11.js
@@ -1,29 +1,29 @@
-function patchElement(oldVdom, newVdom) {
-  const el = oldVdom.el
-  const {
-    class: oldClass,
-    style: oldStyle,
-    on: oldEvents,
-    ...oldAttrs
-  } = oldVdom.props
-  const {
-    class: newClass,
-    style: newStyle,
-    on: newEvents,
-    ...newAttrs
-  } = newVdom.props
-  const { listeners: oldListeners } = oldVdom
+// --add--
+import {
+  removeAttribute,
+  setAttribute,
+} from './attributes'
+// --add--
+import { destroyDOM } from './destroy-dom'
+import { DOM_TYPES } from './h'
+import { mountDOM } from './mount-dom'
+import { areNodesEqual } from './nodes-equal'
+// --add--
+import { objectsDiff } from './utils/objects'
+// --add--
 
-  patchAttrs(el, oldAttrs, newAttrs)
-  patchClasses(el, oldClass, newClass)
-  patchStyles(el, oldStyle, newStyle)
-  newVdom.listeners = patchEvents(el, oldListeners, oldEvents, newEvents)
+// --snip-- //
+
+// --add--
+function patchAttrs(el, oldAttrs, newAttrs) {
+  const { added, removed, updated } = objectsDiff(oldAttrs, newAttrs) // --1--
+
+  for (const attr of removed) {
+    removeAttribute(el, attr) // --2--
+  }
+
+  for (const attr of added.concat(updated)) {
+    setAttribute(el, attr, newAttrs[attr]) // --3--
+  }
 }
-
-// TODO: implement patchAttrs()
-
-// TODO: implement patchClasses()
-
-// TODO: implement patchStyles()
-
-// TODO: implement patchEvents()
+// --add--

--- a/listings/ch08/listing_12.js
+++ b/listings/ch08/listing_12.js
@@ -1,29 +1,41 @@
-// --add--
 import {
   removeAttribute,
   setAttribute,
 } from './attributes'
-// --add--
 import { destroyDOM } from './destroy-dom'
 import { DOM_TYPES } from './h'
 import { mountDOM } from './mount-dom'
 import { areNodesEqual } from './nodes-equal'
 // --add--
+import {
+  arraysDiff,
+} from './utils/arrays'
+// --add--
 import { objectsDiff } from './utils/objects'
+// --add--
+import { isNotBlankOrEmptyString } from './utils/strings'
 // --add--
 
 // --snip-- //
 
 // --add--
-function patchAttrs(el, oldAttrs, newAttrs) {
-  const { added, removed, updated } = objectsDiff(oldAttrs, newAttrs) // --1--
+function patchClasses(el, oldClass, newClass) {
+  const oldClasses = toClassList(oldClass) // --1--
+  const newClasses = toClassList(newClass) // --2--
 
-  for (const attr of removed) {
-    removeAttribute(el, attr) // --2--
+  const { added, removed } = arraysDiff(oldClasses, newClasses) // --3--
+  
+  if (removed.length > 0) {
+    el.classList.remove(...removed) // --4--
   }
+  if (added.length > 0) {
+    el.classList.add(...added) // --5--
+  }
+}
 
-  for (const attr of added.concat(updated)) {
-    setAttribute(el, attr, newAttrs[attr]) // --3--
-  }
+function toClassList(classes = '') { 
+  return Array.isArray(classes)
+    ? classes.filter(isNotBlankOrEmptyString) // --6--
+    : classes.split(/(\s+)/).filter(isNotBlankOrEmptyString) // --7--
 }
 // --add--

--- a/listings/ch08/listing_13.js
+++ b/listings/ch08/listing_13.js
@@ -1,41 +1,7 @@
-import {
-  removeAttribute,
-  setAttribute,
-} from './attributes'
-import { destroyDOM } from './destroy-dom'
-import { DOM_TYPES } from './h'
-import { mountDOM } from './mount-dom'
-import { areNodesEqual } from './nodes-equal'
-// --add--
-import {
-  arraysDiff,
-} from './utils/arrays'
-// --add--
-import { objectsDiff } from './utils/objects'
-// --add--
-import { isNotBlankOrEmptyString } from './utils/strings'
-// --add--
-
-// --snip-- //
-
-// --add--
-function patchClasses(el, oldClass, newClass) {
-  const oldClasses = toClassList(oldClass) // --1--
-  const newClasses = toClassList(newClass) // --2--
-
-  const { added, removed } = arraysDiff(oldClasses, newClasses) // --3--
-  
-  if (removed.length > 0) {
-    el.classList.remove(...removed) // --4--
-  }
-  if (added.length > 0) {
-    el.classList.add(...added) // --5--
-  }
+export function isNotEmptyString(str) {
+  return str !== ''
 }
 
-function toClassList(classes = '') { 
-  return Array.isArray(classes)
-    ? classes.filter(isNotBlankOrEmptyString) // --6--
-    : classes.split(/(\s+)/).filter(isNotBlankOrEmptyString) // --7--
+export function isNotBlankOrEmptyString(str) {
+  return isNotEmptyString(str.trim())
 }
-// --add--

--- a/listings/ch08/listing_14.js
+++ b/listings/ch08/listing_14.js
@@ -1,7 +1,33 @@
-export function isNotEmptyString(str) {
-  return str !== ''
-}
+import {
+  removeAttribute,
+  setAttribute,
+  // --add--
+  removeStyle,
+  setStyle,
+  // --add--
+} from './attributes'
+import { destroyDOM } from './destroy-dom'
+import { DOM_TYPES } from './h'
+import { mountDOM } from './mount-dom'
+import { areNodesEqual } from './nodes-equal'
+import {
+  arraysDiff,
+} from './utils/arrays'
+import { objectsDiff } from './utils/objects'
+import { isNotBlankOrEmptyString } from './utils/strings'
 
-export function isNotBlankOrEmptyString(str) {
-  return isNotEmptyString(str.trim())
+// --snip-- //
+
+// --add--
+function patchStyles(el, oldStyle = {}, newStyle = {}) {
+  const { added, removed, updated } = objectsDiff(oldStyle, newStyle)
+
+  for (const style of removed) {
+    removeStyle(el, style)
+  }
+
+  for (const style of added.concat(updated)) {
+    setStyle(el, style, newStyle[style])
+  }
 }
+// --add--

--- a/listings/ch08/listing_15.js
+++ b/listings/ch08/listing_15.js
@@ -1,12 +1,13 @@
 import {
   removeAttribute,
   setAttribute,
-  // --add--
   removeStyle,
   setStyle,
-  // --add--
 } from './attributes'
 import { destroyDOM } from './destroy-dom'
+// --add--
+import { addEventListener } from './events'
+// --add--
 import { DOM_TYPES } from './h'
 import { mountDOM } from './mount-dom'
 import { areNodesEqual } from './nodes-equal'
@@ -19,15 +20,25 @@ import { isNotBlankOrEmptyString } from './utils/strings'
 // --snip-- //
 
 // --add--
-function patchStyles(el, oldStyle = {}, newStyle = {}) {
-  const { added, removed, updated } = objectsDiff(oldStyle, newStyle)
+function patchEvents(
+  el,
+  oldListeners = {},
+  oldEvents = {},
+  newEvents = {}
+) {
+  const { removed, added, updated } = objectsDiff(oldEvents, newEvents) // --1--
 
-  for (const style of removed) {
-    removeStyle(el, style)
+  for (const eventName of removed.concat(updated)) {
+    el.removeEventListener(eventName, oldListeners[eventName]) // --2--
   }
 
-  for (const style of added.concat(updated)) {
-    setStyle(el, style, newStyle[style])
+  const addedListeners = {} // --3--
+
+  for (const eventName of added.concat(updated)) {
+    const listener = addEventListener(eventName, newEvents[eventName], el) // --4--
+    addedListeners[eventName] = listener // --5--
   }
+
+  return addedListeners // --6--
 }
 // --add--

--- a/listings/ch08/listing_16.js
+++ b/listings/ch08/listing_16.js
@@ -5,40 +5,48 @@ import {
   setStyle,
 } from './attributes'
 import { destroyDOM } from './destroy-dom'
-// --add--
 import { addEventListener } from './events'
-// --add--
 import { DOM_TYPES } from './h'
 import { mountDOM } from './mount-dom'
 import { areNodesEqual } from './nodes-equal'
 import {
   arraysDiff,
+  // --add--
+  arraysDiffSequence,
+  ARRAY_DIFF_OP,
+  // --add--
 } from './utils/arrays'
 import { objectsDiff } from './utils/objects'
 import { isNotBlankOrEmptyString } from './utils/strings'
 
-// --snip-- //
+export function patchDOM(oldVdom, newVdom, parentEl) {
+  if (!areNodesEqual(oldVdom, newVdom)) {
+    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el)
+    destroyDOM(oldVdom)
+    mountDOM(newVdom, parentEl, index)
 
-// --add--
-function patchEvents(
-  el,
-  oldListeners = {},
-  oldEvents = {},
-  newEvents = {}
-) {
-  const { removed, added, updated } = objectsDiff(oldEvents, newEvents) // --1--
-
-  for (const eventName of removed.concat(updated)) {
-    el.removeEventListener(eventName, oldListeners[eventName]) // --2--
+    return newVdom
   }
 
-  const addedListeners = {} // --3--
+  newVdom.el = oldVdom.el
 
-  for (const eventName of added.concat(updated)) {
-    const listener = addEventListener(eventName, newEvents[eventName], el) // --4--
-    addedListeners[eventName] = listener // --5--
+  switch (newVdom.type) {
+    case DOM_TYPES.TEXT: {
+      patchText(oldVdom, newVdom)
+      return newVdom
+    }
+
+    case DOM_TYPES.ELEMENT: {
+      patchElement(oldVdom, newVdom)
+      break
+    }
   }
 
-  return addedListeners // --6--
+  // --add--
+  patchChildren(oldVdom, newVdom)
+  // --add--
+
+  return newVdom
 }
-// --add--
+
+// TODO: implement patchChildren()

--- a/listings/ch08/listing_17.js
+++ b/listings/ch08/listing_17.js
@@ -1,52 +1,17 @@
-import {
-  removeAttribute,
-  setAttribute,
-  removeStyle,
-  setStyle,
-} from './attributes'
-import { destroyDOM } from './destroy-dom'
-import { addEventListener } from './events'
-import { DOM_TYPES } from './h'
-import { mountDOM } from './mount-dom'
-import { areNodesEqual } from './nodes-equal'
-import {
-  arraysDiff,
-  // --add--
-  arraysDiffSequence,
-  ARRAY_DIFF_OP,
-  // --add--
-} from './utils/arrays'
-import { objectsDiff } from './utils/objects'
-import { isNotBlankOrEmptyString } from './utils/strings'
-
-export function patchDOM(oldVdom, newVdom, parentEl) {
-  if (!areNodesEqual(oldVdom, newVdom)) {
-    const index = Array.from(parentEl.childNodes).indexOf(oldVdom.el)
-    destroyDOM(oldVdom)
-    mountDOM(newVdom, parentEl, index)
-
-    return newVdom
+export function extractChildren(vdom) {
+  if (vdom.children == null) {
+    return []
   }
 
-  newVdom.el = oldVdom.el
+  const children = []
 
-  switch (newVdom.type) {
-    case DOM_TYPES.TEXT: {
-      patchText(oldVdom, newVdom)
-      return newVdom
-    }
-
-    case DOM_TYPES.ELEMENT: {
-      patchElement(oldVdom, newVdom)
-      break
+  for (const child of vdom.children) {
+    if (child.type === DOM_TYPES.FRAGMENT) {
+      children.push(...extractChildren(child, children))
+    } else {
+      children.push(child)
     }
   }
 
-  // --add--
-  patchChildren(oldVdom, newVdom)
-  // --add--
-
-  return newVdom
+  return children
 }
-
-// TODO: implement patchChildren()

--- a/listings/ch08/listing_18.js
+++ b/listings/ch08/listing_18.js
@@ -1,6 +1,27 @@
+import {
+  removeAttribute,
+  setAttribute,
+  removeStyle,
+  setStyle,
+} from './attributes'
+import { destroyDOM } from './destroy-dom'
+import { addEventListener } from './events'
+import { DOM_TYPES } from './h'
+import { mountDOM, /*--add--*/extractChildren/*--add--*/} from './mount-dom'
+import { areNodesEqual } from './nodes-equal'
+import {
+  arraysDiff,
+  arraysDiffSequence,
+  ARRAY_DIFF_OP,
+} from './utils/arrays'
+import { objectsDiff } from './utils/objects'
+import { isNotBlankOrEmptyString } from './utils/strings
+
+// --snip-- //
+
 function patchChildren(oldVdom, newVdom) {
-  const oldChildren = oldVdom.children ?? [] // --1--
-  const newChildren = newVdom.children ?? [] // --2--
+  const oldChildren = extractChildren(oldVdom)
+  const newChildren = extractChildren(newVdom)
   const parentEl = oldVdom.el
 
   const diffSeq = arraysDiffSequence( // --3--

--- a/packages/runtime/src/__tests__/destroy-dom.test.js
+++ b/packages/runtime/src/__tests__/destroy-dom.test.js
@@ -47,7 +47,7 @@ test('remove an html element event listeners', () => {
   expect(handler).toHaveBeenCalledTimes(1)
 })
 
-test('destroy an html and its children recursively', () => {
+test('destroy an html element and its children recursively', () => {
   const vdom = h('div', {}, [
     h('p', {}, [hString('hello')]),
     h('span', {}, [hString('world')]),
@@ -72,6 +72,22 @@ test('destroy a fragment', () => {
 
   mountDOM(vdom, document.body)
   expect(document.body.innerHTML).toBe('<div>hello</div><span>world</span>')
+
+  destroyDOM(vdom)
+  expect(document.body.innerHTML).toBe('')
+  expect(allElementsHaveBeenDestroyed(vdom)).toBe(true)
+})
+
+test('destroy a fragment recursively', () => {
+  const vdom = hFragment([
+    h('span', {}, ['hello']),
+    hFragment([h('span', {}, [hString('world')])]),
+  ])
+
+  mountDOM(vdom, document.body)
+  expect(document.body.innerHTML).toBe(
+    '<span>hello</span><span>world</span>'
+  )
 
   destroyDOM(vdom)
   expect(document.body.innerHTML).toBe('')

--- a/packages/runtime/src/__tests__/h.test.js
+++ b/packages/runtime/src/__tests__/h.test.js
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import { h, hString, hFragment, DOM_TYPES } from '../h'
+import { h, hString, hFragment, DOM_TYPES, extractChildren } from '../h'
 
 test('create a string vNode', () => {
   const vNode = hString('test')
@@ -52,8 +52,7 @@ test('h() maps strings to text vNodes', () => {
 
 test('create a fragment vNode', () => {
   const children = [h('div', { class: 'foo' }, [])]
-  const props = { id: 'test' }
-  const vNode = hFragment(children, props)
+  const vNode = hFragment(children)
 
   expect(vNode).toEqual({
     type: DOM_TYPES.FRAGMENT,
@@ -61,7 +60,7 @@ test('create a fragment vNode', () => {
       {
         type: DOM_TYPES.ELEMENT,
         tag: 'div',
-        props: { class: 'foo', ...props },
+        props: { class: 'foo' },
         children: [],
       },
     ],
@@ -70,8 +69,7 @@ test('create a fragment vNode', () => {
 
 test('hFragment() filters null children', () => {
   const children = [h('div', { class: 'foo' }, []), null]
-  const props = { id: 'test' }
-  const vNode = hFragment(children, props)
+  const vNode = hFragment(children)
 
   expect(vNode).toEqual({
     type: DOM_TYPES.FRAGMENT,
@@ -79,14 +77,14 @@ test('hFragment() filters null children', () => {
       {
         type: DOM_TYPES.ELEMENT,
         tag: 'div',
-        props: { class: 'foo', ...props },
+        props: { class: 'foo' },
         children: [],
       },
     ],
   })
 })
 
-test('hFraagment() maps strings to text vNodes', () => {
+test('hFragment() maps strings to text vNodes', () => {
   const vNode = hFragment(['test'])
   expect(vNode).toEqual({
     type: DOM_TYPES.FRAGMENT,
@@ -94,14 +92,23 @@ test('hFraagment() maps strings to text vNodes', () => {
   })
 })
 
-test('fragment props are not added to text nodes', () => {
-  const children = [hString('test')]
-  const props = { id: 'test' }
+test('extract children from a tree with fragments', () => {
+  const vNode = h('div', {}, [
+    'A',
+    hFragment([
+      hFragment([hString('B')]),
+      hString('C'),
+      hFragment([hString('D')]),
+    ]),
+    'E',
+  ])
+  const children = extractChildren(vNode)
 
-  const vNode = hFragment(children, props)
-
-  expect(vNode).toEqual({
-    type: DOM_TYPES.FRAGMENT,
-    children: [{ type: DOM_TYPES.TEXT, value: 'test' }],
-  })
+  expect(children).toEqual([
+    { type: DOM_TYPES.TEXT, value: 'A' },
+    { type: DOM_TYPES.TEXT, value: 'B' },
+    { type: DOM_TYPES.TEXT, value: 'C' },
+    { type: DOM_TYPES.TEXT, value: 'D' },
+    { type: DOM_TYPES.TEXT, value: 'E' },
+  ])
 })

--- a/packages/runtime/src/__tests__/mount-dom.test.js
+++ b/packages/runtime/src/__tests__/mount-dom.test.js
@@ -54,14 +54,6 @@ test('mount a fragment in a host element', () => {
   expect(document.body.innerHTML).toBe('hello, world')
 })
 
-test('mount a fragment inside a host fragment', () => {
-  const host = document.createDocumentFragment()
-  const vdom = hFragment([hString('hello, '), hString('world')])
-  mountDOM(vdom, host)
-
-  expect(host.textContent).toBe('hello, world')
-})
-
 test('mount a fragment inside a fragment inside a host element', () => {
   const vdom = hFragment([
     h('p', {}, ['foo']),

--- a/packages/runtime/src/__tests__/patch-dom.test.js
+++ b/packages/runtime/src/__tests__/patch-dom.test.js
@@ -70,6 +70,22 @@ describe('patch fragments', () => {
 
     expect(document.body.innerHTML).toEqual('foobar<p>baz</p>')
   })
+
+  test('nested fragments, add child at index', () => {
+    const oldVdom = hFragment([
+      hString('A'),
+      hFragment([hString('B'), hString('C')]),
+    ])
+    const newVdom = hFragment([
+      hFragment([hString('X')]),
+      hString('A'),
+      hFragment([hString('B'), hFragment([hString('Y')]), hString('C')]),
+    ])
+
+    patch(oldVdom, newVdom)
+
+    expect(document.body.innerHTML).toEqual('XABYC')
+  })
 })
 
 describe('patch attributes', () => {

--- a/packages/runtime/src/__tests__/patch-dom.test.js
+++ b/packages/runtime/src/__tests__/patch-dom.test.js
@@ -86,6 +86,38 @@ describe('patch fragments', () => {
 
     expect(document.body.innerHTML).toEqual('XABYC')
   })
+
+  test('nested fragments, remove child', () => {
+    const oldVdom = hFragment([
+      hFragment([hString('X')]),
+      hString('A'),
+      hFragment([hString('B'), hFragment([hString('Y')]), hString('C')]),
+    ])
+    const newVdom = hFragment([
+      hString('A'),
+      hFragment([hString('B'), hString('C')]),
+    ])
+
+    patch(oldVdom, newVdom)
+
+    expect(document.body.innerHTML).toEqual('ABC')
+  })
+
+  test('nested fragments, move child', () => {
+    const oldVdom = hFragment([
+      hString('A'),
+      hFragment([hString('B'), hString('C')]),
+    ])
+    const newVdom = hFragment([
+      hFragment([hString('B')]),
+      hString('A'),
+      hFragment([hString('C')]),
+    ])
+
+    patch(oldVdom, newVdom)
+
+    expect(document.body.innerHTML).toEqual('BAC')
+  })
 })
 
 describe('patch attributes', () => {

--- a/packages/runtime/src/__tests__/patch-dom.test.js
+++ b/packages/runtime/src/__tests__/patch-dom.test.js
@@ -58,6 +58,20 @@ test('patch text', () => {
   expect(document.body.innerHTML).toEqual('bar')
 })
 
+describe('patch fragments', () => {
+  test('nested fragments, add child', () => {
+    const oldVdom = hFragment([hFragment([hString('foo')])])
+    const newVdom = hFragment([
+      hFragment([hString('foo'), hString('bar')]),
+      h('p', {}, ['baz']),
+    ])
+
+    patch(oldVdom, newVdom)
+
+    expect(document.body.innerHTML).toEqual('foobar<p>baz</p>')
+  })
+})
+
 describe('patch attributes', () => {
   test('add attribute', () => {
     const oldVdom = h('div', {})

--- a/packages/runtime/src/destroy-dom.js
+++ b/packages/runtime/src/destroy-dom.js
@@ -27,7 +27,7 @@ export function destroyDOM(vdom) {
     }
 
     case DOM_TYPES.FRAGMENT: {
-      removeFragmentNode(vdom)
+      removeFragmentNodes(vdom)
       break
     }
 
@@ -61,7 +61,7 @@ function removeElementNode(vdom) {
   }
 }
 
-function removeFragmentNode(vdom) {
+function removeFragmentNodes(vdom) {
   const { el, children } = vdom
 
   assert(el instanceof HTMLElement)

--- a/packages/runtime/src/mount-dom.js
+++ b/packages/runtime/src/mount-dom.js
@@ -14,8 +14,6 @@ import { DOM_TYPES } from './h'
  * @param {number} [index] the index at the parent element to mount the virtual DOM node to
  */
 export function mountDOM(vdom, parentEl, index) {
-  ensureIsValidParent(parentEl)
-
   switch (vdom.type) {
     case DOM_TYPES.TEXT: {
       createTextNode(vdom, parentEl, index)
@@ -28,7 +26,7 @@ export function mountDOM(vdom, parentEl, index) {
     }
 
     case DOM_TYPES.FRAGMENT: {
-      createFragmentNode(vdom, parentEl, index)
+      createFragmentNodes(vdom, parentEl)
       break
     }
 
@@ -98,43 +96,17 @@ function addProps(el, props, vdom) {
 }
 
 /**
- * Creates the fragment for a virtual DOM fragment node and its children recursively.
- * The vdom's `el` property is set to be the `parentEl` passed to the function.
- * This is because a fragment loses its children when it is appended to the DOM, so
- * we can't use it to reference the fragment's children.
- *
- * Note that `DocumentFragment` is a subclass of `Node`, but not of `Element`.
- *
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment}
+ * Creates the nodes for the children of a virtual DOM fragment node and appends them to the
+ * parent element.
  *
  * @param {import('./h').FragmentVNode} vdom the virtual DOM node of type "fragment"
  * @param {Element} parentEl the host element to mount the virtual DOM node to
- * @param {number} [index] the index at the parent element to mount the virtual DOM node to
  */
-function createFragmentNode(vdom, parentEl, index) {
+function createFragmentNodes(vdom, parentEl) {
   const { children } = vdom
-
-  const fragment = document.createDocumentFragment()
   vdom.el = parentEl
 
   children.forEach((child) => mountDOM(child, parentEl))
-  insert(fragment, parentEl, index)
-}
-
-function ensureIsValidParent(
-  parentEl,
-  errMsg = 'A parent element must be provided'
-) {
-  if (!parent) {
-    throw new Error(errMsg)
-  }
-
-  const isElement = parentEl instanceof Element
-  const isFragment = parentEl instanceof DocumentFragment
-
-  if (!(isElement || isFragment)) {
-    throw new Error(errMsg)
-  }
 }
 
 /**

--- a/packages/runtime/src/patch-dom.js
+++ b/packages/runtime/src/patch-dom.js
@@ -6,7 +6,7 @@ import {
 } from './attributes'
 import { destroyDOM } from './destroy-dom'
 import { addEventListener } from './events'
-import { DOM_TYPES } from './h'
+import { DOM_TYPES, extractChildren } from './h'
 import { mountDOM } from './mount-dom'
 import { areNodesEqual } from './nodes-equal'
 import {
@@ -245,8 +245,8 @@ function patchEvents(
  * @param {import('./h').VNode} newVdom the new virtual node
  */
 function patchChildren(oldVdom, newVdom) {
-  const oldChildren = oldVdom.children ?? []
-  const newChildren = newVdom.children ?? []
+  const oldChildren = extractChildren(oldVdom)
+  const newChildren = extractChildren(newVdom)
   const parentEl = oldVdom.el
 
   const diffSeq = arraysDiffSequence(


### PR DESCRIPTION
Fixes #77 

## Summary 

The native fragments add more complexity than problems they solve.
Initially, their usage was due to improvements in performance versus adding the nodes individually, but [the MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment#performance) states that:

> The performance benefit of DocumentFragment is often overstated. In fact, in some engines, using a DocumentFragment is slower than appending to the document in a loop [...]

Since the main objective of this framework is being instructive, I decided to get rid of `document.createDocumentFragment()` in favor of simply appending the fragment's children into the parent element.

## Reconciliation

One situation where the fragments get problematic is in the reconciliation algorithm.
When two virtual DOM trees are compared, to find what changed and patch the DOM accordingly, the structure becomes important.

As surfaced [by this unit test](https://github.com/angelsolaorbaiceta/fe-fwk-book/pull/80/files#diff-3990e7c91af1a91a78e11566f04542a594fac9a21410c646d99ae2c5b5bee3e6R62), patching a vDOM with nested fragments becomes problematic, because they point to the same parent element (the `<body>` in that case), but are appended in an order that doesn't necessarily corresponds to where they are in the virtual DOM tree.

**The solution** is to get rid of `DocumentFragment` instances when mounting the DOM and to extract the children of a node, where a fragment is flat-mapped to its children, before doing the patching.
