### PR TITLE
fix (runtime): Use the original index for the move operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5439,7 +5439,7 @@
     },
     "packages/runtime": {
       "name": "fe-fwk",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-c8": "^0.31.4",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fe-fwk",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A frontend framework to teach web developers how frontend frameworks work.",
   "keywords": [
     "frontend",

--- a/packages/runtime/src/__tests__/diff-sequence.test.js
+++ b/packages/runtime/src/__tests__/diff-sequence.test.js
@@ -12,9 +12,24 @@ test('equal arrays', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 1 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 1, item: 2 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 2, index: 2, item: 3 },
+    {
+      op: ARRAY_DIFF_OP.NOOP,
+      originalIndex: 0,
+      index: 0,
+      item: 1,
+    },
+    {
+      op: ARRAY_DIFF_OP.NOOP,
+      originalIndex: 1,
+      index: 1,
+      item: 2,
+    },
+    {
+      op: ARRAY_DIFF_OP.NOOP,
+      originalIndex: 2,
+      index: 2,
+      item: 3,
+    },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -27,8 +42,8 @@ test('item removed from the beginning', () => {
 
   expect(diffSeq).toEqual([
     { op: ARRAY_DIFF_OP.REMOVE, index: 0, item: 'a' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 0, item: 'b' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 2, index: 1, item: 'c' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 0, item: 'b' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 2, index: 1, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -40,8 +55,8 @@ test('item removed from the end', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'a' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 1, item: 'b' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 1, item: 'b' },
     { op: ARRAY_DIFF_OP.REMOVE, index: 2, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
@@ -54,9 +69,9 @@ test('item removed from the middle', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'a' },
     { op: ARRAY_DIFF_OP.REMOVE, item: 'b', index: 1 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 2, index: 1, item: 'c' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 2, index: 1, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -69,8 +84,8 @@ test('item added at the beginning', () => {
 
   expect(diffSeq).toEqual([
     { op: ARRAY_DIFF_OP.ADD, item: 'a', index: 0 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 1, item: 'b' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 2, item: 'c' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 1, item: 'b' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 2, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -82,8 +97,8 @@ test('item added at the end', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'a' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 1, item: 'b' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 1, item: 'b' },
     { op: ARRAY_DIFF_OP.ADD, item: 'c', index: 2 },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
@@ -96,9 +111,9 @@ test('item added at the middle', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'a' },
     { op: ARRAY_DIFF_OP.ADD, item: 'b', index: 1 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 2, item: 'c' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 2, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -110,9 +125,9 @@ test('item added in the middle of two equal elements', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'a' },
     { op: ARRAY_DIFF_OP.ADD, item: 'b', index: 1 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 2, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 2, item: 'a' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -124,7 +139,7 @@ test('item removed from two equal elements (the second is removed)', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'b' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'b' },
     { op: ARRAY_DIFF_OP.REMOVE, item: 'b', index: 1 },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
@@ -137,10 +152,10 @@ test('item removed and new one added in the same place', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'a' },
     { op: ARRAY_DIFF_OP.REMOVE, item: 'b', index: 1 },
     { op: ARRAY_DIFF_OP.ADD, item: 'd', index: 1 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 2, index: 2, item: 'c' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 2, index: 2, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -152,12 +167,12 @@ test('two middle items replaced', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 0, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 0, item: 'a' },
     { op: ARRAY_DIFF_OP.REMOVE, item: 'b', index: 1 },
     { op: ARRAY_DIFF_OP.REMOVE, item: 'c', index: 1 },
     { op: ARRAY_DIFF_OP.ADD, item: 'X', index: 1 },
     { op: ARRAY_DIFF_OP.ADD, item: 'Y', index: 2 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 3, index: 3, item: 'd' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 3, index: 3, item: 'd' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -170,8 +185,8 @@ test('two items moved', () => {
 
   expect(diffSeq).toEqual([
     { op: ARRAY_DIFF_OP.MOVE, from: 1, index: 0, item: 'b' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 1, item: 'a' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 2, index: 2, item: 'c' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 1, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 2, index: 2, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -184,10 +199,10 @@ test('remove, add and move', () => {
 
   expect(diffSeq).toEqual([
     { op: ARRAY_DIFF_OP.REMOVE, item: 'a', index: 0 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 0, item: 'b' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 0, item: 'b' },
     { op: ARRAY_DIFF_OP.ADD, item: 'X', index: 1 },
     { op: ARRAY_DIFF_OP.MOVE, item: 'd', from: 3, index: 2 },
-    { op: ARRAY_DIFF_OP.NOOP, from: 2, index: 3, item: 'c' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 2, index: 3, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
 })
@@ -200,7 +215,7 @@ test('remove repeated element, add and move', () => {
   expect(diffSeq).toEqual([
     { op: ARRAY_DIFF_OP.MOVE, from: 3, index: 0, item: 'c' },
     { op: ARRAY_DIFF_OP.ADD, index: 1, item: 'k' },
-    { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 2, item: 'a' },
+    { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 2, item: 'a' },
     { op: ARRAY_DIFF_OP.MOVE, from: 4, index: 3, item: 'b' },
     { op: ARRAY_DIFF_OP.REMOVE, index: 4, item: 'a' },
   ])
@@ -215,8 +230,8 @@ test.each([
     newArray: ['c', 'a', 'b'],
     expected: [
       { op: ARRAY_DIFF_OP.MOVE, item: 'c', from: 2, index: 0 },
-      { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 1, item: 'a' },
-      { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 2, item: 'b' },
+      { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 1, item: 'a' },
+      { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 2, item: 'b' },
     ],
   },
   {
@@ -225,7 +240,7 @@ test.each([
     expected: [
       { op: ARRAY_DIFF_OP.MOVE, item: 'b', from: 1, index: 0 },
       { op: ARRAY_DIFF_OP.MOVE, item: 'c', from: 2, index: 1 },
-      { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 2, item: 'a' },
+      { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 2, item: 'a' },
     ],
   },
   {
@@ -233,9 +248,9 @@ test.each([
     newArray: ['c', 'a', 'b', 'd'],
     expected: [
       { op: ARRAY_DIFF_OP.MOVE, item: 'c', from: 2, index: 0 },
-      { op: ARRAY_DIFF_OP.NOOP, from: 0, index: 1, item: 'a' },
-      { op: ARRAY_DIFF_OP.NOOP, from: 1, index: 2, item: 'b' },
-      { op: ARRAY_DIFF_OP.NOOP, from: 3, index: 3, item: 'd' },
+      { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 1, item: 'a' },
+      { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 2, item: 'b' },
+      { op: ARRAY_DIFF_OP.NOOP, originalIndex: 3, index: 3, item: 'd' },
     ],
   },
 ])(
@@ -248,7 +263,6 @@ test.each([
   }
 )
 
-// Cases failing in fuzz testing
 test('removes the items at the end', () => {
   const oldArray = [
     'a',

--- a/packages/runtime/src/__tests__/diff-sequence.test.js
+++ b/packages/runtime/src/__tests__/diff-sequence.test.js
@@ -184,7 +184,13 @@ test('two items moved', () => {
   const diffSeq = arraysDiffSequence(oldArray, newArray)
 
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.MOVE, from: 1, index: 0, item: 'b' },
+    {
+      op: ARRAY_DIFF_OP.MOVE,
+      originalIndex: 1,
+      from: 1,
+      index: 0,
+      item: 'b',
+    },
     { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 1, item: 'a' },
     { op: ARRAY_DIFF_OP.NOOP, originalIndex: 2, index: 2, item: 'c' },
   ])
@@ -201,7 +207,13 @@ test('remove, add and move', () => {
     { op: ARRAY_DIFF_OP.REMOVE, item: 'a', index: 0 },
     { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 0, item: 'b' },
     { op: ARRAY_DIFF_OP.ADD, item: 'X', index: 1 },
-    { op: ARRAY_DIFF_OP.MOVE, item: 'd', from: 3, index: 2 },
+    {
+      op: ARRAY_DIFF_OP.MOVE,
+      item: 'd',
+      originalIndex: 3,
+      from: 3,
+      index: 2,
+    },
     { op: ARRAY_DIFF_OP.NOOP, originalIndex: 2, index: 3, item: 'c' },
   ])
   expect(applyArraysDiffSequence(oldArray, diffSeq)).toEqual(newArray)
@@ -213,10 +225,22 @@ test('remove repeated element, add and move', () => {
 
   const diffSeq = arraysDiffSequence(oldArray, newArray)
   expect(diffSeq).toEqual([
-    { op: ARRAY_DIFF_OP.MOVE, from: 3, index: 0, item: 'c' },
+    {
+      op: ARRAY_DIFF_OP.MOVE,
+      originalIndex: 3,
+      from: 3,
+      index: 0,
+      item: 'c',
+    },
     { op: ARRAY_DIFF_OP.ADD, index: 1, item: 'k' },
     { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 2, item: 'a' },
-    { op: ARRAY_DIFF_OP.MOVE, from: 4, index: 3, item: 'b' },
+    {
+      op: ARRAY_DIFF_OP.MOVE,
+      originalIndex: 2,
+      from: 4,
+      index: 3,
+      item: 'b',
+    },
     { op: ARRAY_DIFF_OP.REMOVE, index: 4, item: 'a' },
   ])
 
@@ -229,7 +253,13 @@ test.each([
     oldArray: ['a', 'b', 'c'],
     newArray: ['c', 'a', 'b'],
     expected: [
-      { op: ARRAY_DIFF_OP.MOVE, item: 'c', from: 2, index: 0 },
+      {
+        op: ARRAY_DIFF_OP.MOVE,
+        item: 'c',
+        originalIndex: 2,
+        from: 2,
+        index: 0,
+      },
       { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 1, item: 'a' },
       { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 2, item: 'b' },
     ],
@@ -238,8 +268,20 @@ test.each([
     oldArray: ['a', 'b', 'c'],
     newArray: ['b', 'c', 'a'],
     expected: [
-      { op: ARRAY_DIFF_OP.MOVE, item: 'b', from: 1, index: 0 },
-      { op: ARRAY_DIFF_OP.MOVE, item: 'c', from: 2, index: 1 },
+      {
+        op: ARRAY_DIFF_OP.MOVE,
+        item: 'b',
+        originalIndex: 1,
+        from: 1,
+        index: 0,
+      },
+      {
+        op: ARRAY_DIFF_OP.MOVE,
+        item: 'c',
+        originalIndex: 2,
+        from: 2,
+        index: 1,
+      },
       { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 2, item: 'a' },
     ],
   },
@@ -247,7 +289,13 @@ test.each([
     oldArray: ['a', 'b', 'c', 'd'],
     newArray: ['c', 'a', 'b', 'd'],
     expected: [
-      { op: ARRAY_DIFF_OP.MOVE, item: 'c', from: 2, index: 0 },
+      {
+        op: ARRAY_DIFF_OP.MOVE,
+        item: 'c',
+        originalIndex: 2,
+        from: 2,
+        index: 0,
+      },
       { op: ARRAY_DIFF_OP.NOOP, originalIndex: 0, index: 1, item: 'a' },
       { op: ARRAY_DIFF_OP.NOOP, originalIndex: 1, index: 2, item: 'b' },
       { op: ARRAY_DIFF_OP.NOOP, originalIndex: 3, index: 3, item: 'd' },

--- a/packages/runtime/src/__tests__/patch-dom.test.js
+++ b/packages/runtime/src/__tests__/patch-dom.test.js
@@ -395,6 +395,24 @@ describe('patch children', () => {
 
       expect(document.body.innerHTML).toBe('<div>CAB</div>')
     })
+
+    test('recursively', () => {
+      const oldVdom = hFragment([
+        h('p', {}, ['A']),
+        h('span', {}, ['B']),
+        h('div', {}, ['C']),
+      ])
+      const newVdom = hFragment([
+        h('div', {}, ['C']),
+        h('span', { id: 'b' }, ['B']),
+      ])
+
+      patch(oldVdom, newVdom)
+
+      expect(document.body.innerHTML).toBe(
+        '<div>C</div><span id="b">B</span>'
+      )
+    })
   })
 
   describe('element vnode', () => {

--- a/packages/runtime/src/patch-dom.js
+++ b/packages/runtime/src/patch-dom.js
@@ -256,7 +256,7 @@ function patchChildren(oldVdom, newVdom) {
   )
 
   for (const operation of diffSeq) {
-    const { from, index, item } = operation
+    const { originalIndex, index, item } = operation
 
     switch (operation.op) {
       case ARRAY_DIFF_OP.ADD: {
@@ -270,17 +270,19 @@ function patchChildren(oldVdom, newVdom) {
       }
 
       case ARRAY_DIFF_OP.MOVE: {
-        const el = oldChildren[from].el
+        const oldChild = oldChildren[originalIndex]
+        const newChild = newChildren[index]
+        const el = oldChild.el
         const elAtTargetIndex = parentEl.childNodes[index]
 
         parentEl.insertBefore(el, elAtTargetIndex)
-        patchDOM(oldChildren[from], newChildren[index], parentEl)
+        patchDOM(oldChild, newChild, parentEl)
 
         break
       }
 
       case ARRAY_DIFF_OP.NOOP: {
-        patchDOM(oldChildren[from], newChildren[index], parentEl)
+        patchDOM(oldChildren[originalIndex], newChildren[index], parentEl)
         break
       }
     }

--- a/packages/runtime/src/utils/arrays.js
+++ b/packages/runtime/src/utils/arrays.js
@@ -266,8 +266,8 @@ class ArrayWithOriginalIndices {
   noopItem(index) {
     return {
       op: ARRAY_DIFF_OP.NOOP,
-      from: this.originalIndexAt(index),
       index,
+      originalIndex: this.originalIndexAt(index),
       item: this.#array[index],
     }
   }

--- a/packages/runtime/src/utils/arrays.js
+++ b/packages/runtime/src/utils/arrays.js
@@ -319,6 +319,7 @@ class ArrayWithOriginalIndices {
 
     const operation = {
       op: ARRAY_DIFF_OP.MOVE,
+      originalIndex: this.originalIndexAt(fromIndex),
       from: fromIndex,
       index: toIndex,
       item: this.#array[fromIndex],


### PR DESCRIPTION
# Summary 

Fixes an issue where  a move operation (in the context of the `arraysDiffSequence()` function) didn't include the original index, and thus `patchChildren()` was mistakenly passing two unrelated nodes to `patchDOM()` in some circumstances.