### PR TITLE
feat (compiler): Compile HTML templates into render functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5215,7 +5215,12 @@
     "packages/compiler": {
       "name": "fe-fwk-compiler",
       "version": "0.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^0.34.4",
+        "eslint": "^8.49.0",
+        "vitest": "^0.34.4"
+      }
     },
     "packages/loader": {
       "name": "fe-fwk-loader",
@@ -6563,7 +6568,12 @@
       }
     },
     "fe-fwk-compiler": {
-      "version": "file:packages/compiler"
+      "version": "file:packages/compiler",
+      "requires": {
+        "@vitest/coverage-v8": "^0.34.4",
+        "eslint": "^8.49.0",
+        "vitest": "^0.34.4"
+      }
     },
     "fe-fwk-loader": {
       "version": "file:packages/loader"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,6 +1309,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/boxen": {
       "version": "5.1.2",
       "dev": true,
@@ -1652,6 +1657,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "dev": true,
@@ -1770,6 +1801,30 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "dev": true,
@@ -1779,6 +1834,33 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/duplexer": {
@@ -1800,7 +1882,6 @@
     },
     "node_modules/entities": {
       "version": "4.4.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2316,10 +2397,7 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "he": "bin/he"
       }
@@ -3365,6 +3443,15 @@
         "node": "^12.13 || ^14.13 || >=16"
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.10.tgz",
+      "integrity": "sha512-6/uWdWxjQWQ7tMcFK2wWlrflsQUzh1HsEzlIf2j5+TtzfhT2yUvg3DwZYAmjEHeR3uX74ko7exjHW69J0tOzIg==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "6.0.0",
       "dev": true,
@@ -3532,6 +3619,17 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nwsapi": {
@@ -5216,6 +5314,9 @@
       "name": "fe-fwk-compiler",
       "version": "0.0.0",
       "license": "MIT",
+      "dependencies": {
+        "node-html-parser": "^6.1.10"
+      },
       "devDependencies": {
         "@vitest/coverage-v8": "^0.34.4",
         "eslint": "^8.49.0",
@@ -6049,6 +6150,11 @@
       "version": "1.0.2",
       "dev": true
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "boxen": {
       "version": "5.1.2",
       "dev": true,
@@ -6279,6 +6385,23 @@
         "which": "^2.0.1"
       }
     },
+    "css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
     "css.escape": {
       "version": "1.5.1",
       "dev": true,
@@ -6354,11 +6477,44 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
     "domexception": {
       "version": "4.0.0",
       "dev": true,
       "requires": {
         "webidl-conversions": "^7.0.0"
+      }
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
       }
     },
     "duplexer": {
@@ -6377,8 +6533,7 @@
       }
     },
     "entities": {
-      "version": "4.4.0",
-      "dev": true
+      "version": "4.4.0"
     },
     "env-paths": {
       "version": "2.2.1",
@@ -6572,6 +6727,7 @@
       "requires": {
         "@vitest/coverage-v8": "^0.34.4",
         "eslint": "^8.49.0",
+        "node-html-parser": "^6.1.10",
         "vitest": "^0.34.4"
       }
     },
@@ -6749,10 +6905,7 @@
       "dev": true
     },
     "he": {
-      "version": "1.2.0",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "version": "1.2.0"
     },
     "hosted-git-info": {
       "version": "6.1.1",
@@ -7473,6 +7626,15 @@
         "which": "^2.0.2"
       }
     },
+    "node-html-parser": {
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.10.tgz",
+      "integrity": "sha512-6/uWdWxjQWQ7tMcFK2wWlrflsQUzh1HsEzlIf2j5+TtzfhT2yUvg3DwZYAmjEHeR3uX74ko7exjHW69J0tOzIg==",
+      "requires": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "nopt": {
       "version": "6.0.0",
       "dev": true,
@@ -7589,6 +7751,14 @@
         "console-control-strings": "^1.1.0",
         "gauge": "^4.0.3",
         "set-blocking": "^2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "requires": {
+        "boolbase": "^1.0.0"
       }
     },
     "nwsapi": {

--- a/packages/compiler/.eslintrc.js
+++ b/packages/compiler/.eslintrc.js
@@ -1,0 +1,13 @@
+export default {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: 'eslint:recommended',
+  overrides: [],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {},
+}

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -2,9 +2,15 @@
   "name": "fe-fwk-compiler",
   "version": "0.0.0",
   "description": "Compiles fe-fwk templates into JS render functions",
-  "main": "index.js",
+  "main": "dist/fe-fwk-compiler.js",
   "scripts": {
-    "test": "test"
+    "build": "rollup -c",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "test:coverage": "vitest run --coverage",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -15,5 +21,10 @@
   "bugs": {
     "url": "https://github.com/angelsolaorbaiceta/fe-fwk-book/issues"
   },
-  "homepage": "https://github.com/angelsolaorbaiceta/fe-fwk-book#readme"
+  "homepage": "https://github.com/angelsolaorbaiceta/fe-fwk-book#readme",
+  "devDependencies": {
+    "@vitest/coverage-v8": "^0.34.4",
+    "eslint": "^8.49.0",
+    "vitest": "^0.34.4"
+  }
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -26,5 +26,8 @@
     "@vitest/coverage-v8": "^0.34.4",
     "eslint": "^8.49.0",
     "vitest": "^0.34.4"
+  },
+  "dependencies": {
+    "node-html-parser": "^6.1.10"
   }
 }

--- a/packages/compiler/src/__tests__/compile.test.js
+++ b/packages/compiler/src/__tests__/compile.test.js
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest'
+import { TemplateCompiler } from '../compile'
+import { singleJSLine } from './utils'
+
+const compiler = new TemplateCompiler()
+
+test('Compile and empty <div> element', () => {
+  const { code, imports } = compiler.compile('<div></div>')
+
+  expect(imports).toEqual(new Set(['h']))
+  expect(code).toBe(singleJSLine`
+    function render() {
+      return ( h('div', {}, [ ]) )
+    }`)
+})
+
+test('Compile element with text content', () => {
+  const { code, imports } = compiler.compile('<div>Hello World</div>')
+
+  expect(imports).toEqual(new Set(['h', 'hString']))
+  expect(code).toBe(singleJSLine`
+    function render() {
+      return ( h('div', {}, [ hString('Hello World'), ]) )
+    }`)
+})

--- a/packages/compiler/src/__tests__/compile.test.js
+++ b/packages/compiler/src/__tests__/compile.test.js
@@ -23,3 +23,16 @@ test('Compile element with text content', () => {
       return ( h('div', {}, [ hString('Hello World'), ]) )
     }`)
 })
+
+test.only('Compile two contiguous elements inside a fragment', () => {
+  const { code, imports } = compiler.compile('<div></div><p></p>')
+
+  expect(imports).toEqual(new Set(['h', 'hFragment']))
+  expect(code).toBe(singleJSLine`
+    function render() {
+      return ( h(Fragment, {}, [ 
+        h('div', {}, [ ]), 
+        h('p', {}, [ ]), 
+      ]) )
+    }`)
+})

--- a/packages/compiler/src/__tests__/compile.test.js
+++ b/packages/compiler/src/__tests__/compile.test.js
@@ -20,11 +20,11 @@ test('Compile element with text content', () => {
   expect(imports).toEqual(new Set(['h', 'hString']))
   expect(code).toBe(singleJSLine`
     function render() {
-      return ( h('div', {}, [ hString('Hello World'), ]) )
+      return ( h('div', {}, [ hString('Hello World') ]) )
     }`)
 })
 
-test.only('Compile two contiguous elements inside a fragment', () => {
+test('Compile two contiguous elements inside a fragment', () => {
   const { code, imports } = compiler.compile('<div></div><p></p>')
 
   expect(imports).toEqual(new Set(['h', 'hFragment']))
@@ -32,7 +32,19 @@ test.only('Compile two contiguous elements inside a fragment', () => {
     function render() {
       return ( h(Fragment, {}, [ 
         h('div', {}, [ ]), 
-        h('p', {}, [ ]), 
+        h('p', {}, [ ]) 
+      ]) )
+    }`)
+})
+
+test('Compile nested elements', () => {
+  const { code, imports } = compiler.compile('<div><p>Hello</p></div>')
+
+  expect(imports).toEqual(new Set(['h', 'hString']))
+  expect(code).toBe(singleJSLine`
+    function render() {
+      return ( h('div', {}, [ 
+        h('p', {}, [ hString('Hello') ]) 
       ]) )
     }`)
 })

--- a/packages/compiler/src/__tests__/compile.test.js
+++ b/packages/compiler/src/__tests__/compile.test.js
@@ -48,3 +48,34 @@ test('Compile nested elements', () => {
       ]) )
     }`)
 })
+
+test('Compile props interpolation', () => {
+  const { code } = compiler.compile('<p>{{ props.text }}</p>')
+
+  expect(code).toBe(singleJSLine`
+    function render() {
+      return ( h('p', {}, [ hString(\`\${this.props.text}\`) ]) )
+    }`)
+})
+
+test('Compile state interpolation', () => {
+  const { code } = compiler.compile('<p>{{ state.text }}</p>')
+
+  expect(code).toBe(singleJSLine`
+    function render() {
+      return ( h('p', {}, [ hString(\`\${this.state.text}\`) ]) )
+    }`)
+})
+
+test('Compile props and state interpolation along with regular text', () => {
+  const { code } = compiler.compile(
+    '<p>{{ props.text }} - {{ state.text }}</p>'
+  )
+
+  expect(code).toBe(singleJSLine`
+    function render() {
+      return ( h('p', {}, [ 
+        hString(\`\${this.props.text} - \${this.state.text}\`) 
+      ]) )
+    }`)
+})

--- a/packages/compiler/src/__tests__/utils.js
+++ b/packages/compiler/src/__tests__/utils.js
@@ -1,0 +1,3 @@
+export function singleJSLine(str) {
+  return str[0].replace(/\s+/g, ' ').trim()
+}

--- a/packages/compiler/src/compile.js
+++ b/packages/compiler/src/compile.js
@@ -1,5 +1,7 @@
 import { parse } from 'node-html-parser'
 import { normalizeTagName } from './tag'
+import { extractProps } from './props'
+import { interpolateVariables } from './variables'
 
 const NODE_TYPE = {
   ELEMENT: 1,
@@ -66,7 +68,9 @@ export class TemplateCompiler {
     const { rawTagName, childNodes, attributes } = node
 
     const tag = normalizeTagName(rawTagName)
-    this.#lines.push(`h(${tag}, {}, [`)
+    const props = extractProps(attributes)
+
+    this.#lines.push(`h(${tag}, ${props}, [`)
     this.#imports.add('h')
     this.#stack.unshift(']),')
 
@@ -80,7 +84,7 @@ export class TemplateCompiler {
     const text = rawText.trim()
 
     if (text) {
-      this.#lines.push(`hString('${text}'),`)
+      this.#lines.push(`hString(${interpolateVariables(text)}),`)
       this.#imports.add('hString')
     }
   }

--- a/packages/compiler/src/compile.js
+++ b/packages/compiler/src/compile.js
@@ -104,69 +104,6 @@ export class TemplateCompiler {
   }
 }
 
-export function compileTemplate(template) {
-  const { childNodes } = parse(normalize(template))
-  const lines = ['function render() {', 'return (']
-  const stack = [')', '}']
-  const imports = new Set()
-
-  for (const node of childNodes) {
-    addNode(node)
-  }
-
-  if (lines[lines.length - 1].endsWith(',')) {
-    lines[lines.length - 1] = lines[lines.length - 1].slice(0, -1)
-  }
-
-  while (stack.length) {
-    addLineFromStack()
-  }
-
-  function addLineFromStack() {
-    const line = stack.shift()
-    lines.push(line)
-  }
-
-  function addNode(node) {
-    switch (node.nodeType) {
-      case NODE_TYPE.ELEMENT: {
-        addElement(node)
-        break
-      }
-      case NODE_TYPE.TEXT: {
-        addText(node)
-        break
-      }
-    }
-  }
-
-  function addElement(node) {
-    const { rawTagName, childNodes, attributes } = node
-
-    const tag = normalizeTagName(rawTagName)
-    lines.push(`h(${tag}, {}, [`)
-    imports.add('h')
-
-    childNodes.forEach(addNode)
-
-    stack.unshift(']),')
-  }
-
-  function addText(node) {
-    const { rawText } = node
-    const text = rawText.trim()
-
-    if (text) {
-      lines.push(`'${text}',`)
-    }
-  }
-
-  return {
-    imports: imports,
-    code: lines.join(' '),
-  }
-}
-
 /**
  * Removes newlines and replaces all the whitespace between tags.
  *

--- a/packages/compiler/src/compile.js
+++ b/packages/compiler/src/compile.js
@@ -39,7 +39,9 @@ export class TemplateCompiler {
       this.#addNode(node)
     }
 
-    this.#moveStackToLines()
+    while (this.#stack.length) {
+      this.#addLineFromStack()
+    }
 
     return {
       imports: this.#imports,
@@ -88,19 +90,13 @@ export class TemplateCompiler {
     const prevIdx = this.#lines.length - 1
     const prevLine = this.#lines[prevIdx]
 
-    // Avoid the comma if the next character is a closing parenthesis.
-    // The ",)" sequence is not valid JavaScript.
-    if (prevLine.endsWith(',') && line.startsWith(')')) {
+    // Remove the trailing comma in the previous line if the
+    // next character is a closing parenthesis or bracket.
+    if (/,\s*$/.test(prevLine) && /^\s*[\)\]]/.test(line)) {
       this.#lines[prevIdx] = prevLine.slice(0, -1)
     }
 
     this.#lines.push(line)
-  }
-
-  #moveStackToLines() {
-    while (this.#stack.length) {
-      this.#addLineFromStack()
-    }
   }
 }
 

--- a/packages/compiler/src/compile.js
+++ b/packages/compiler/src/compile.js
@@ -1,7 +1,162 @@
+import { parse } from 'node-html-parser'
+import { normalizeTagName } from './tag'
+
+const NODE_TYPE = {
+  ELEMENT: 1,
+  TEXT: 3,
+}
+
+export class TemplateCompiler {
+  #lines = []
+  #stack = []
+  #imports = new Set()
+
+  #reset() {
+    this.#lines = ['function render() {', 'return (']
+    this.#stack = [')', '}']
+    this.#imports = new Set()
+  }
+
+  /**
+   * Compiles the given HTML template into a render function.
+   * It transforms the directives into JavaScript code.
+   *
+   * @param {string} template the HTML template to compile
+   * @returns {object} the compiled render function
+   */
+  compile(template) {
+    this.#reset()
+    const { childNodes } = parse(normalize(template))
+
+    for (const node of childNodes) {
+      this.#addNode(node)
+    }
+
+    while (this.#stack.length) {
+      let line = this.#stack.shift()
+      const prevIdx = this.#lines.length - 1
+      const prevLine = this.#lines[prevIdx]
+
+      // Avoid the comma if the next character is a closing parenthesis.
+      // The ",)" sequence is not valid JavaScript.
+      if (prevLine.endsWith(',') && line.startsWith(')')) {
+        this.#lines[prevIdx] = prevLine.slice(0, -1)
+      }
+
+      this.#lines.push(line)
+    }
+
+    return {
+      imports: this.#imports,
+      code: this.#lines.join(' '),
+    }
+  }
+
+  #addNode(node) {
+    switch (node.nodeType) {
+      case NODE_TYPE.ELEMENT: {
+        this.#addElement(node)
+        break
+      }
+      case NODE_TYPE.TEXT: {
+        this.#addText(node)
+        break
+      }
+    }
+  }
+
+  #addElement(node) {
+    const { rawTagName, childNodes, attributes } = node
+
+    const tag = normalizeTagName(rawTagName)
+    this.#lines.push(`h(${tag}, {}, [`)
+    this.#imports.add('h')
+
+    childNodes.forEach((node) => this.#addNode(node))
+
+    this.#stack.unshift(']),')
+  }
+
+  #addText(node) {
+    const { rawText } = node
+    const text = rawText.trim()
+
+    if (text) {
+      this.#lines.push(`hString('${text}'),`)
+      this.#imports.add('hString')
+    }
+  }
+}
+
+export function compileTemplate(template) {
+  const { childNodes } = parse(normalize(template))
+  const lines = ['function render() {', 'return (']
+  const stack = [')', '}']
+  const imports = new Set()
+
+  for (const node of childNodes) {
+    addNode(node)
+  }
+
+  if (lines[lines.length - 1].endsWith(',')) {
+    lines[lines.length - 1] = lines[lines.length - 1].slice(0, -1)
+  }
+
+  while (stack.length) {
+    addLineFromStack()
+  }
+
+  function addLineFromStack() {
+    const line = stack.shift()
+    lines.push(line)
+  }
+
+  function addNode(node) {
+    switch (node.nodeType) {
+      case NODE_TYPE.ELEMENT: {
+        addElement(node)
+        break
+      }
+      case NODE_TYPE.TEXT: {
+        addText(node)
+        break
+      }
+    }
+  }
+
+  function addElement(node) {
+    const { rawTagName, childNodes, attributes } = node
+
+    const tag = normalizeTagName(rawTagName)
+    lines.push(`h(${tag}, {}, [`)
+    imports.add('h')
+
+    childNodes.forEach(addNode)
+
+    stack.unshift(']),')
+  }
+
+  function addText(node) {
+    const { rawText } = node
+    const text = rawText.trim()
+
+    if (text) {
+      lines.push(`'${text}',`)
+    }
+  }
+
+  return {
+    imports: imports,
+    code: lines.join(' '),
+  }
+}
+
 /**
- * Compiles the given HTML template into a render function.
- * It transforms the directives into JavaScript code.
+ * Removes newlines and replaces all the whitespace between tags.
  *
- * @param {string} template the HTML template to compile
+ * @param {string} str the string to normalize
+ * @returns {string} the normalized string
  */
-export function compileTemplate(template) {}
+function normalize(str) {
+  return str.replace(/\n/g, ' ').replace(/>\s+</g, '><').trim()
+}

--- a/packages/compiler/src/compile.js
+++ b/packages/compiler/src/compile.js
@@ -1,0 +1,7 @@
+/**
+ * Compiles the given HTML template into a render function.
+ * It transforms the directives into JavaScript code.
+ *
+ * @param {string} template the HTML template to compile
+ */
+export function compileTemplate(template) {}

--- a/packages/compiler/src/context.js
+++ b/packages/compiler/src/context.js
@@ -1,0 +1,6 @@
+export function addThisContext(str) {
+  return str
+    .replaceAll('state.', 'this.state.')
+    .replaceAll('props.', 'this.props.')
+    .trim()
+}

--- a/packages/compiler/src/props.js
+++ b/packages/compiler/src/props.js
@@ -1,0 +1,34 @@
+import { addThisContext } from './context'
+
+const attributeBindingRegex = /^\[([a-zA-Z0-9_-]+)\]$/
+
+export function extractProps(attrs) {
+  const props = {}
+
+  for (const attrName in attrs) {
+    if (attributeBindingRegex.test(attrName)) {
+      const propName = attrName.match(attributeBindingRegex)[1]
+      props[propName] = addThisContext(attrs[attrName])
+
+      continue
+    }
+
+    props[attrName] = `'${attrs[attrName]}'`
+  }
+
+  return propsToString(props)
+}
+
+function propsToString(props) {
+  const content = Object.keys(props)
+    .map((name) => {
+      const value = props[name]
+      return `${name}: ${
+        typeof value === 'object' ? propsToString(value) : value
+      }`
+    })
+    .join(', ')
+    .trim()
+
+  return content ? `{ ${content} }` : '{}'
+}

--- a/packages/compiler/src/tag.js
+++ b/packages/compiler/src/tag.js
@@ -1,0 +1,15 @@
+export function normalizeTagName(tag) {
+  return isComponentName(tag) ? normalizeComponentName(tag) : `'${tag}'`
+}
+
+export function isComponentName(tag) {
+  return /[A-Z-]+/.test(tag)
+}
+
+function normalizeComponentName(tag) {
+  return (
+    'this.components.' +
+    tag[0].toUpperCase() +
+    tag.slice(1).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+  )
+}

--- a/packages/compiler/src/variables.js
+++ b/packages/compiler/src/variables.js
@@ -1,0 +1,15 @@
+import { addThisContext } from './context'
+
+const variableInterpolationRegex = /{{\s*([^{}]+)\s*}}/g
+
+export function interpolateVariables(str) {
+  if (!variableInterpolationRegex.test(str)) {
+    return `'${str}'`
+  }
+
+  const replaced = str.replaceAll(variableInterpolationRegex, (_, name) => {
+    return '${' + addThisContext(name) + '}'
+  })
+
+  return '`' + replaced + '`'
+}

--- a/packages/compiler/vitest.config.js
+++ b/packages/compiler/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['**/__tests__/**/*.test.js'],
+    reporters: 'verbose',
+    coverage: {
+      provider: 'v8',
+    },
+  },
+})


### PR DESCRIPTION
# Compile Templates

Implements the `TemplateCompiler` class used to compile HTML templates into render functions.


## Context

Users prefer to describe the UI using HTML instead of building virtual node trees in code.
The compiler transforms those HTML templates into the `render()` function that creates the virtual DOM that the framework requires to build the user interfaces.

