### PR TITLE
[#177] Handle text children that are of type number, boolean, etc

### DIFF
--- a/packages/runtime/src/__tests__/h.test.js
+++ b/packages/runtime/src/__tests__/h.test.js
@@ -50,6 +50,21 @@ test('h() maps strings to text vNodes', () => {
   })
 })
 
+test("h() maps 'number', 'boolean', 'bigint', and 'symbol' values to text vNodes", () => {
+  const vNode = h('div', {}, [0, true, BigInt(10000000000), Symbol(5)])
+  expect(vNode).toEqual({
+    tag: 'div',
+    props: {},
+    children: [ 
+        { type: DOM_TYPES.TEXT, value: '0' }, 
+        { type: DOM_TYPES.TEXT, value: 'true' },
+        { type: DOM_TYPES.TEXT, value: '10000000000' },
+        { type: DOM_TYPES.TEXT, value: 'Symbol(5)' }
+    ],
+    type: DOM_TYPES.ELEMENT,
+  })
+})
+
 test('create a fragment vNode', () => {
   const children = [h('div', { class: 'foo' }, [])]
   const vNode = hFragment(children)

--- a/packages/runtime/src/h.js
+++ b/packages/runtime/src/h.js
@@ -111,10 +111,8 @@ export function hFragment(vNodes) {
 }
 
 /**
- * Maps text children of VNode to TextVNode
+ * Maps strings, numbers, booleans and symbos inside the array to text vNodes.
  * 
- * Children of JavaScript types 'string', 'number', 'boolean',
- * 'bigint', and 'symbol' will be mapped to TextVNode 
  * @param {array} children the children of the VNode
  * @returns {VNode[]} the children with text children mapped to TextVNode
  */

--- a/packages/runtime/src/h.js
+++ b/packages/runtime/src/h.js
@@ -81,7 +81,7 @@ export function h(tag, props = {}, children = []) {
  * @returns {TextVNode} the virtual node
  */
 export function hString(str) {
-  return { type: DOM_TYPES.TEXT, value: str }
+  return { type: DOM_TYPES.TEXT, value: String(str) }
 }
 
 /**
@@ -110,9 +110,22 @@ export function hFragment(vNodes) {
   }
 }
 
+/**
+ * Maps text children of VNode to TextVNode
+ * 
+ * Children of JavaScript types 'string', 'number', 'boolean',
+ * 'bigint', and 'symbol' will be mapped to TextVNode 
+ * @param {array} children the children of the VNode
+ * @returns {VNode[]} the children with text children mapped to TextVNode
+ */
 function mapTextNodes(children) {
   return children.map((child) =>
-    typeof child === 'string' ? hString(child) : child
+    (typeof child === 'string'
+      || typeof child === 'number'
+      || typeof child === 'boolean'
+      || typeof child === 'bigint'
+      || typeof child === 'symbol'
+    ) ? hString(child) : child
   )
 }
 


### PR DESCRIPTION
# Fix the issue where text children that are not of type string did not get mapped to TextVNode.

## Context

See Issue #177.
