### PR TITLE
fix (runtime): `createFragmentNode()` adds the right amount to the index where the new nodes will be inserted

### DIFF
--- a/packages/runtime/src/mount-dom.js
+++ b/packages/runtime/src/mount-dom.js
@@ -125,9 +125,24 @@ function createFragmentNodes(vdom, parentEl, index, hostComponent) {
   const { children } = vdom
   vdom.el = parentEl
 
-  children.forEach((child, i) =>
-    mountDOM(child, parentEl, index ? index + i : null, hostComponent)
-  )
+  for (const child of children) {
+    mountDOM(child, parentEl, index, hostComponent)
+
+    if (index == null) {
+      continue
+    }
+
+    switch (child.type) {
+      case DOM_TYPES.FRAGMENT:
+        index += child.children.length
+        break
+      case DOM_TYPES.COMPONENT:
+        index += child.component.elements.length
+        break
+      default:
+        index++
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
# Fix the `createFragmentNode()` index addition logic

The `createFragmentNode()` function in the _mount-dom.js_ file was incorrectly incrementing the `index` variable where the children of a fragment were added.

Thanks to @sabatavdgiridze for reporting [in this discussion thread](https://github.com/angelsolaorbaiceta/fe-fwk-book/discussions/237#discussioncomment-8736270).
Your valuable description of the problem and the great diagram accompanying it made me realize where the issue was.

## Context

The `createFragmentNode()` function was implemented like follows:

```javascript
function createFragmentNodes(vdom, parentEl, index, hostComponent) {
  const { children } = vdom
  vdom.el = parentEl

  children.forEach((child, i) =>
    mountDOM(child, parentEl, index ? index + i : null, hostComponent)
  )
}
```

But the logic incrementing the `index` variable (`index ? index + i : null`) has two issues:

1. When `index = 0` the condition `index ? index + 1 : null` evaluates `0` in a boolean context and yields `false` (JS, wtf??). Thus, instead of prepending the element, it was appended at the end (a `null` value for `index` means appending).
2. There are two cases where incrementing the `index` by one fails:
    - When the node is of `type == 'component'`: in this case, the component's view might have more than one top-level nodes. This happens when the component returns a fragment. The `index` variable needs to be incremented according to the number of items in that fragment.
    - When the node is of `type == 'fragment'`: in this case, the `index` variable also needs to be incremented according to the number of items in that fragment.

## The Fix

Fixing this issue is as simple as changing the logic that increments the `index` variable to account for the cases of components with fragments an fragments:

```javascript
function createFragmentNodes(vdom, parentEl, index, hostComponent) {
  const { children } = vdom
  vdom.el = parentEl

  for (const child of children) {
    mountDOM(child, parentEl, index, hostComponent)

    if (index == null) {
      continue
    }

    switch (child.type) {
      case DOM_TYPES.FRAGMENT:
        index += child.children.length
        break
      case DOM_TYPES.COMPONENT:
        index += child.component.elements.length
        break
      default:
        index++
    }
  }
}
```