### PR TITLE
Removes the extra parameter passed into the extractChildren() function

### DIFF
--- a/packages/runtime/src/h.js
+++ b/packages/runtime/src/h.js
@@ -223,7 +223,7 @@ export function extractChildren(vdom) {
 
   for (const child of vdom.children) {
     if (child.type === DOM_TYPES.FRAGMENT) {
-      children.push(...extractChildren(child, children))
+      children.push(...extractChildren(child))
     } else {
       children.push(child)
     }


### PR DESCRIPTION
# Removes the extra parameter passed into the extractChildren() function

Hi Angel, Thanks so much for your great book! I am enthusiastically learning how to build a frontend framework based on your clear explanation, well-organized code, and thought-provoking exercises!

I'm creating this PR today as I found a bit of confusion in line 226 in the file `packages/runtime/src/h.js`:
The original code is `children.push(...extractChildren(child, children))`, but I found the function `extractChildren(vdom)` only takes one parameter, that means the second parameter `children` in the recursive call above might be an extra one and does not really take part in the algorithm. Therefore I guess maybe we can delete this extra one.

After removing the `children` parameter, I reran the test, and all of the test cases passed successfully. 

Thanks for considering this modification. Also, please let me know if I understand this part of the code incorrectly!
