### PR TITLE
fix (runtime): `arraysDiff()` with duplicates

### DIFF
--- a/packages/runtime/src/__tests__/arrays.test.js
+++ b/packages/runtime/src/__tests__/arrays.test.js
@@ -54,4 +54,58 @@ describe('arrays diff', () => {
       removed: [3],
     })
   })
+
+  test('duplicated item where one unit is removed', () => {
+    const oldArray = [1, 1]
+    const newArray = [1]
+
+    expect(arraysDiff(oldArray, newArray)).toEqual({
+      added: [],
+      removed: [1],
+    })
+  })
+
+  test('duplicated item where two items are removed', () => {
+    const oldArray = [1, 1]
+    const newArray = []
+
+    expect(arraysDiff(oldArray, newArray)).toEqual({
+      added: [],
+      removed: [1, 1],
+    })
+  })
+
+  test('duplicated item where one unit is added', () => {
+    const oldArray = [1]
+    const newArray = [1, 1]
+
+    expect(arraysDiff(oldArray, newArray)).toEqual({
+      added: [1],
+      removed: [],
+    })
+  })
+
+  test('duplicated item where two units are added', () => {
+    const oldArray = []
+    const newArray = [1, 1]
+
+    expect(arraysDiff(oldArray, newArray)).toEqual({
+      added: [1, 1],
+      removed: [],
+    })
+  })
+
+  test('array with duplicates', () => {
+    const oldArray = [1, 1, 2, 2, 3, 3, 3]
+    const newArray = [1, 1, 1, 2, 3, 4, 4]
+
+    const { added, removed } = arraysDiff(oldArray, newArray)
+    added.sort()
+    removed.sort()
+
+    expect({ added, removed }).toEqual({
+      added: [1, 4, 4],
+      removed: [2, 3, 3],
+    })
+  })
 })

--- a/packages/runtime/src/__tests__/maps.test.js
+++ b/packages/runtime/src/__tests__/maps.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest'
+import { makeCountMap, mapsDiff } from '../utils/maps.js'
+
+describe('make count map', () => {
+  test('empty array', () => {
+    expect(makeCountMap([])).toEqual(new Map())
+  })
+
+  test('array with one item', () => {
+    expect(makeCountMap(['A'])).toEqual(new Map([['A', 1]]))
+  })
+
+  test('array without duplicates', () => {
+    expect(makeCountMap(['A', 'B', 'C'])).toEqual(
+      new Map([
+        ['A', 1],
+        ['B', 1],
+        ['C', 1],
+      ])
+    )
+  })
+
+  test('array with duplicates', () => {
+    expect(makeCountMap(['A', 'B', 'A', 'C', 'B', 'B'])).toEqual(
+      new Map([
+        ['A', 2],
+        ['B', 3],
+        ['C', 1],
+      ])
+    )
+  })
+})
+
+describe('maps diff', () => {
+  test('empty maps', () => {
+    const oldMap = new Map()
+    const newMap = new Map()
+
+    expect(mapsDiff(oldMap, newMap)).toEqual({
+      added: [],
+      removed: [],
+      updated: [],
+    })
+  })
+
+  test('maps with the same keys and values', () => {
+    const oldMap = new Map([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+    const newMap = new Map([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+
+    expect(mapsDiff(oldMap, newMap)).toEqual({
+      added: [],
+      removed: [],
+      updated: [],
+    })
+  })
+
+  test('maps with the same keys but different values', () => {
+    const oldMap = new Map([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+    const newMap = new Map([
+      ['a', 1],
+      ['b', 4],
+      ['c', 3],
+    ])
+
+    expect(mapsDiff(oldMap, newMap)).toEqual({
+      added: [],
+      removed: [],
+      updated: ['b'],
+    })
+  })
+
+  test('maps with different keys', () => {
+    const oldMap = new Map([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+    const newMap = new Map([
+      ['a', 1],
+      ['b', 2],
+      ['d', 3],
+    ])
+
+    expect(mapsDiff(oldMap, newMap)).toEqual({
+      added: ['d'],
+      removed: ['c'],
+      updated: [],
+    })
+  })
+})

--- a/packages/runtime/src/utils/arrays.js
+++ b/packages/runtime/src/utils/arrays.js
@@ -48,12 +48,12 @@ export function arraysDiff(oldArray, newArray) {
   for (const key of diff.updated) {
     const oldCount = oldsCount.get(key)
     const newCount = newsCount.get(key)
-    const diff = newCount - oldCount
+    const delta = newCount - oldCount
 
-    if (diff > 0) {
-      added.push(...Array(diff).fill(key))
+    if (delta > 0) {
+      added.push(...Array(delta).fill(key))
     } else {
-      removed.push(...Array(-diff).fill(key))
+      removed.push(...Array(-delta).fill(key))
     }
   }
 

--- a/packages/runtime/src/utils/arrays.js
+++ b/packages/runtime/src/utils/arrays.js
@@ -25,6 +25,12 @@ export function withoutNulls(arr) {
  * Given two arrays, it returns the items that have been added to the new array
  * and the items that have been removed from the old array.
  *
+ * NOTE TO READERS: your implementation of this function if you followed along
+ * with the book's chapter 7 listing is different from what's here. The version
+ * I wrote in the book has a bug, as it doesn't deal with duplicated items.
+ *
+ * @see https://github.com/angelsolaorbaiceta/fe-fwk-book/wiki/Errata#bug-in-the-arraysdiff-function check the errata for more information
+ *
  * @param {any[]} oldArray the old array
  * @param {any[]} newArray the new array
  * @returns {{added: any[], removed: any[]}}

--- a/packages/runtime/src/utils/maps.js
+++ b/packages/runtime/src/utils/maps.js
@@ -1,0 +1,75 @@
+/**
+ * Given two maps, returns the keys that have been added, removed or updated.
+ * The comparison is shallow—only the first level of keys is compared.
+ * The keys keep their original type.
+ *
+ * For example:
+ *
+ * Given the following maps:
+ *
+ * ```js
+ * const oldMap = new Map([
+ *   ['a', 1],
+ *   ['b', 2],
+ *   ['c', 3],
+ * ])
+ * const newMap = new Map([
+ *   ['a', 1],
+ *   ['b', 4],
+ *   ['d', 5],
+ * ])
+ * ```
+ *
+ * The result will be:
+ *
+ * ```js
+ * mapsDiff(oldMap, newMap)
+ * // { added: ['d'], removed: ['c'], updated: ['b'] }
+ * ```
+ *
+ * @param {Map<any, any>} oldMap the old map
+ * @param {Map<any, any>} newMap the new map
+ *  * @returns {{added: any[], removed: any[], updated: any[]}}
+ */
+export function mapsDiff(oldMap, newMap) {
+  const oldKeys = Array.from(oldMap.keys())
+  const newKeys = Array.from(newMap.keys())
+
+  return {
+    added: newKeys.filter((key) => !oldMap.has(key)),
+    removed: oldKeys.filter((key) => !newMap.has(key)),
+    updated: newKeys.filter(
+      (key) => oldMap.has(key) && oldMap.get(key) !== newMap.get(key)
+    ),
+  }
+}
+
+/**
+ * Creates a `Map` that counts the occurrences of each item in the given array.
+ * The keys of the `Map` are the items in the array, and the values are the
+ * number of times each item appears in the array.
+ *
+ * A `Map` is used instead of an object because it can store any type of key,
+ * while an object can only store string keys. Thus, the key type is preserved.
+ *
+ * For example, given the array `[A, B, A, C, B, A]`, the object would be:
+ * ```
+ * {
+ *    A: 3,
+ *    B: 2,
+ *    C: 1
+ * }
+ * ```
+ *
+ * @param {any[]} array an array of items
+ * @returns {Map<any, number>} a map of item counts
+ */
+export function makeCountMap(array) {
+  const map = new Map()
+
+  for (const item of array) {
+    map.set(item, (map.get(item) || 0) + 1)
+  }
+
+  return map
+}

--- a/packages/runtime/src/utils/objects.js
+++ b/packages/runtime/src/utils/objects.js
@@ -1,6 +1,23 @@
 /**
  * Given two objects, returns the keys that have been added, removed or updated.
  * The comparison is shallow—only the first level of keys is compared.
+ * Note that the keys are always returned as strings.
+ *
+ * For example:
+ *
+ * Given the following objects:
+ *
+ * ```js
+ * const oldObj = { a: 1, b: 2, c: 3 }
+ * const newObj = { a: 1, b: 4, d: 5 }
+ * ```
+ *
+ * The result will be:
+ *
+ * ```js
+ * objectsDiff(oldObj, newObj)
+ * // { added: ['d'], removed: ['c'], updated: ['b'] }
+ * ```
  *
  * @param {object} oldObj the old object
  * @param {object} newObj the new object


### PR DESCRIPTION
# `arraysDiff()` handles duplicate entries

Closes #260 .

As noted by @terrence-ou , the current implementation of the `arraysDiff()` function doesn't deal with duplicate values.
For example:

```js
const oldArray = []
const newArray = [1, 1]

arraysDiff(oldArray, newArray)
```

Would incorrectly return:

```js
{
  added: [1],
  removed: [],
}
```

When the correct solution would have been that two `1`s were added:

```js
{
  added: [1, 1],
  removed: [],
}
```

This error didn't surface earlier because, the only use of the `arraysDiff()` function is to find the CSS classes that were added/removed from an element.
The browser deduplicates the CSS classes added to an element, and thus, this error has no visible effect in the inner working of the framework.
It's nevertheless a very interesting problem.


## The Problem

The problem is in how the added and removed items are searched for:

- added: `newArray.filter((newItem) => !oldArray.includes(newItem))`
- removed: `oldArray.filter((oldItem) => !newArray.includes(oldItem))`

That `includes()` usage stops at the first match, thus missing duplicates.


## Solution

Solving this problem requires to count how many times a given item appears in each array.
A count map is created for each array for this purpose:

```js
export function arraysDiff(oldArray, newArray) {
  const oldsCount = makeCountMap(oldArray)
  const newsCount = makeCountMap(newArray)

   ...
}
```

The `makeCountMap()` function is straightforward to implement:

```js
export function makeCountMap(array) {
  const map = new Map()

  for (const item of array) {
    map.set(item, (map.get(item) || 0) + 1)
  }

  return map
}
```

Then, we diff the keys of both maps:

```js
const diff = mapsDiff(oldsCount, newsCount)
```

> [!NOTE] 
> Note that we need to use maps and not objects, because objects don't allow types other than `string` and `Symbol` to be the keys.
> Maps don't impose a type to be used as keys.

The `mapsDiff()` function implementation is equivalent to the `objectsDiff()` one, but this time, the keys can be anything and not just `string`s or `Symbol`s:

```js
export function mapsDiff(oldMap, newMap) {
  const oldKeys = Array.from(oldMap.keys())
  const newKeys = Array.from(newMap.keys())

  return {
    added: newKeys.filter((key) => !oldMap.has(key)),
    removed: oldKeys.filter((key) => !newMap.has(key)),
    updated: newKeys.filter(
      (key) => oldMap.has(key) && oldMap.get(key) !== newMap.get(key)
    ),
  }
}
```

Then, in the `arraysDiff()` function, we have not only to see what items were added or removed, but count how many times they were added or removed:

```js
export function arraysDiff(oldArray, newArray) {
  const oldsCount = makeCountMap(oldArray)
  const newsCount = makeCountMap(newArray)
  const diff = mapsDiff(oldsCount, newsCount)

  // Added items repeated as many times as they appear in the new array
  const added = diff.added.flatMap((key) =>
    Array(newsCount.get(key)).fill(key)
  )

  // Removed items repeated as many times as they appeared in the old array
  const removed = diff.removed.flatMap((key) =>
    Array(oldsCount.get(key)).fill(key)
  )

  ...
}
```

And lastly, for the keys that were updated (items that appear in both arrays, but in a different number) we want to calculate the difference between how many times it appears in the new versus the old array.
Based on the result, we include it as addition or removal:

```js
  // Updated items have to check the difference in counts
  for (const key of diff.updated) {
    const oldCount = oldsCount.get(key)
    const newCount = newsCount.get(key)
    const diff = newCount - oldCount

    if (diff > 0) {
      added.push(...Array(diff).fill(key))
    } else {
      removed.push(...Array(-diff).fill(key))
    }
  }
```

And hence the complete implementation is:

```js
export function arraysDiff(oldArray, newArray) {
  const oldsCount = makeCountMap(oldArray)
  const newsCount = makeCountMap(newArray)
  const diff = mapsDiff(oldsCount, newsCount)

  // Added items repeated as many times as they appear in the new array
  const added = diff.added.flatMap((key) =>
    Array(newsCount.get(key)).fill(key)
  )

  // Removed items repeated as many times as they appeared in the old array
  const removed = diff.removed.flatMap((key) =>
    Array(oldsCount.get(key)).fill(key)
  )

  // Updated items have to check the difference in counts
  for (const key of diff.updated) {
    const oldCount = oldsCount.get(key)
    const newCount = newsCount.get(key)
    const delta = newCount - oldCount

    if (delta > 0) {
      added.push(...Array(delta).fill(key))
    } else {
      removed.push(...Array(-delta).fill(key))
    }
  }

  return {
    added,
    removed,
  }
}
```

Thanks @terrence-ou for reporting this error! 🤝




