### PR TITLE
deps (cli): Upgrade versions

### DIFF
--- a/packages/cli/templates/init/package/package.json
+++ b/packages/cli/templates/init/package/package.json
@@ -24,11 +24,11 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^8.47.0",
-    "jsdom": "^22.1.0",
-    "rollup": "^3.28.1",
+    "eslint": "^9.35.0",
+    "jsdom": "^26.1.0",
+    "rollup": "^4.50.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-filesize": "^10.0.0",
-    "vitest": "^0.34.3"
+    "vitest": "^3.2.3"
   }
 }


### PR DESCRIPTION
# Update lib versions in CLI

When the CLI is used to create the project, these are the versions it uses for the installed dependencies.
They were a bit dated, so here I use more modern ones.
