### PR TITLE
disabled caching for the http-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "packages/cli"
   ],
   "scripts": {
-    "serve:examples": "npx http-server . -o ./examples/ -bg"
+    "serve:examples": "npx http-server . -o ./examples/ -bg -c-1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Title

Disable caching for the http-server (affects .js and .css files)

## Context

The http-server library uses caching [by default](https://github.com/http-party/http-server?tab=readme-ov-file#usage) (sets 3600 seconds for cache-control max-age header). It means that .js and .css files will stay in cache for this period, and will be used even if original files have been changed during that time.

There are several solutions:
1. Using hard reset on the browser each time the files change, which is slightly unintuitive, especially for those who are not aware of this feature;
2. Disabling this mechanism and forcing the client to request the files each time, which can be done by setting the cache-control to -1 second. With this option the browser will always use the latest version of .js and .css files;

## Potential caveats

If the server was working before the option was applied, new requests will still use cached files until the timer runs out. This behavior could be fixed by running a hard reset in the browser once
