### PR TITLE
:bug: Fix event listener duplication after view/edit toggles (ch12 Todo)

### DIFF
--- a/packages/runtime/src/patch-dom.js
+++ b/packages/runtime/src/patch-dom.js
@@ -248,12 +248,12 @@ function patchEvents(
   hostComponent
 ) {
   const { removed, added, updated } = objectsDiff(oldEvents, newEvents)
+  const listeners = { ...oldListeners }
 
   for (const eventName of removed.concat(updated)) {
     el.removeEventListener(eventName, oldListeners[eventName])
+    delete listeners[eventName]
   }
-
-  const addedListeners = {}
 
   for (const eventName of added.concat(updated)) {
     const listener = addEventListener(
@@ -262,10 +262,10 @@ function patchEvents(
       el,
       hostComponent
     )
-    addedListeners[eventName] = listener
+    listeners[eventName] = listener
   }
 
-  return addedListeners
+  return listeners
 }
 
 /**


### PR DESCRIPTION
**Summary**

This PR fixes a bug where DOM event listeners get duplicated after  view/edit toggles in the ch12 Todo example (and similar patterns). After a few (or even single) edits, the “Done” button ends up with multiple `click` handlers attached.

**Root cause**

`patchEvents` returned a fresh `{}` when there were no changes in the `on` handlers. This caused `newVdom.listeners` to lose references to the existing DOM listeners, so later updates could not remove the old ones and new listeners were added on top.

**Fix**

- Update `patchEvents` to:
  - Start from a copy of `oldListeners`.
  - Remove listeners only for removed/updated events.
  - Add listeners for added/updated events.
  - Return the full updated `listeners` map.

This keeps `vdom.listeners` in sync with the actual listeners on the DOM element and prevents accumulation.

**Tests**

- Added a regression test in `packages/runtime` to ensure:
  - Listeners are preserved when events don’t change.
  - Old listeners are removed and not duplicated when handlers are updated.

Fixes #453
